### PR TITLE
Fix initial release

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ## Description
 
-&lt;Please fill in the description of all the changes included in this Pull Request&gt;
+Please fill in the description of all the changes included in this Pull Request.
 
 ## Checklist
 

--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -13,7 +13,7 @@ defaults: { run: { shell: bash } }
 jobs:
   test-with-stack:
     if: github.event.pull_request.head.repo.full_name != github.repository
-    name: Test with Stack
+    name: Stack
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -44,7 +44,7 @@ jobs:
       STACK_ARGS: '--resolver ${{ matrix.resolver }} --system-ghc'
       cache-version: v1 # bump up this version to invalidate currently stored cache
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: haskell/actions/setup@v2
       id: setup-haskell-cabal
@@ -81,10 +81,12 @@ jobs:
         curl -sSL https://raw.githubusercontent.com/lehins/utils/master/haskell/git-modtime/git-modtime.hs -o git-modtime.hs
         runhaskell -- git-modtime.hs -f .stack-work/tree-contents.txt
     - name: Build
+      env:
+        COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
       run: |
         set -ex
         [ -n "${{ matrix.stack-yaml }}" ] && STACK_YAML=${{ matrix.stack-yaml }}
-        if [ "${{ matrix.os }}.${{ matrix.resolver }}" == "ubuntu-latest.lts-14" ] && [ -n "${COVERALLS_TOKEN}" ]; then
+        if [ "${{ matrix.os }}.${{ matrix.resolver }}" == "ubuntu-latest.lts-20" ] && [ -n "${COVERALLS_TOKEN}" ]; then
           stack $STACK_ARGS build --coverage --test --no-run-tests --haddock --no-haddock-deps
         else
           stack $STACK_ARGS build --test --no-run-tests --haddock --no-haddock-deps
@@ -101,7 +103,7 @@ jobs:
           curl -L https://github.com/rubik/stack-hpc-coveralls/releases/download/v0.0.6.1/shc-linux-x64-9.2.5.tar.bz2 | tar xj shc
           ./shc --repo-token="$COVERALLS_TOKEN" --partial-coverage --fetch-coverage combined custom
         else
-          stack $STACK_ARGS test :tests
+          stack $STACK_ARGS test :tests --haddock --no-haddock-deps
         fi
     - name: Run doctests
       run: |
@@ -111,7 +113,7 @@ jobs:
 
   test-with-cabal:
     if: github.event.pull_request.head.repo.full_name != github.repository
-    name: Test with Cabal
+    name: Cabal
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -145,7 +147,7 @@ jobs:
     env:
       cache-version: v1 # bump up this version to invalidate currently stored cache
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - uses: haskell/actions/setup@v2
       id: setup-haskell-cabal

--- a/FailT.cabal
+++ b/FailT.cabal
@@ -1,5 +1,5 @@
 name:                FailT
-version:             0.1.0.0
+version:             0.1.0.1
 synopsis:            A 'FailT' monad transformer that plays well with 'MonadFail'
 description:
     Fail gracefully when stuck in a 'MonadFail'

--- a/Setup.hs
+++ b/Setup.hs
@@ -2,6 +2,3 @@ import Distribution.Simple
 
 main :: IO ()
 main = defaultMain
-
-#endif
-


### PR DESCRIPTION
## Description

Fixes an erroneous remnant of CPP in `Setup.hs`. Baffles me that neither one of `stack`, `cabal`, `hackage` or `stackage` caught this issue. Makes me believe that Setup.hs is not used whenever setup is set to `Simple` in the cabal file.

Fixes #1

## Checklist

Please include this checklist whenever changes are introduced to `FailT` package:

* [x] Bump up the version in cabal file, when applicable.
* [x] Any changes that could be relevant to users have been recorded in the `CHANGELOG.md`
* [x] The documentation has been updated, if necessary.
* [x] Property tests or at least some unit test cases have been added for all new functionality.
* [x] Linked issues that might be related to this Pull Request.

## Formatting requirement:

All Haskell files in this repository are formatted with [fourmolu](https://github.com/fourmolu/fourmolu). Configuration files [`fourmolu.yaml`](https://github.com/lehins/massiv/blob/master/fourmolu.yaml) is included at the top level. CI will fail on any PR that doesn't have the Haskell source files properly formatted
