### PR TITLE
Adapt to removal of MonadFix re-export in mtl-2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog for `FailT`
 
+## 0.1.1.1
+
+* Compatiblity with mtl-2.3
+
 ## 0.1.1.0
 
 * Remove unnecessary `IsString` constraint from instance definitions for GHC >= 8.10

--- a/FailT.cabal
+++ b/FailT.cabal
@@ -1,5 +1,5 @@
 name:                FailT
-version:             0.1.1.0
+version:             0.1.1.1
 synopsis:            A 'FailT' monad transformer that plays well with 'MonadFail'
 description:
     Fail gracefully when stuck in a 'MonadFail'

--- a/src/Control/Monad/Trans/Fail.hs
+++ b/src/Control/Monad/Trans/Fail.hs
@@ -56,6 +56,7 @@ import Control.Exception
 import Control.Monad.Catch (MonadThrow (throwM))
 import Control.Monad.Cont
 import Control.Monad.Except
+import Control.Monad.Fix
 import qualified Control.Monad.Fail as F
 import Control.Monad.RWS.Class (MonadRWS)
 import Control.Monad.Reader

--- a/src/Control/Monad/Trans/Fail.hs
+++ b/src/Control/Monad/Trans/Fail.hs
@@ -56,7 +56,9 @@ import Control.Exception
 import Control.Monad.Catch (MonadThrow (throwM))
 import Control.Monad.Cont
 import Control.Monad.Except
+#if MIN_VERSION_mtl(2,3,0)
 import Control.Monad.Fix
+#endif
 import qualified Control.Monad.Fail as F
 import Control.Monad.RWS.Class (MonadRWS)
 import Control.Monad.Reader


### PR DESCRIPTION
## Description

Make this library compatible with mtl-2.3

## Checklist

Please include this checklist whenever changes are introduced to `FailT` package:

* [X] Bump up the version in cabal file, when applicable.
* [X] Any changes that could be relevant to users have been recorded in the `CHANGELOG.md`
* [ ] The documentation has been updated, if necessary.
* [ ] Property tests or at least some unit test cases have been added for all new functionality.
* [ ] Linked issues that might be related to this Pull Request.

## Formatting requirement:

All Haskell files in this repository are formatted with [fourmolu](https://github.com/fourmolu/fourmolu). Configuration files [`fourmolu.yaml`](https://github.com/lehins/massiv/blob/master/fourmolu.yaml) is included at the top level. CI will fail on any PR that doesn't have the Haskell source files properly formatted
